### PR TITLE
electron v12 support

### DIFF
--- a/exStickGE_dram_hdmiout/tools/UDP_DRAM_HDMI_Testtool/src/main.js
+++ b/exStickGE_dram_hdmiout/tools/UDP_DRAM_HDMI_Testtool/src/main.js
@@ -23,7 +23,8 @@ function createWindow() {
         width: 800,
         height: 600,
         webPreferences: {
-            nodeIntegration: true
+            nodeIntegration: true,
+            contextIsolation: false
         }
     });
 


### PR DESCRIPTION
Electron v12以降ではcontextIsolationがデフォルトTrueとなり、レンダラーオブジェクト間通信ができなくなった。contextBridgeを使ってセキュアに作るべきらしい。
contextIsolation=falseとしてセキュアではないが従来通り動くようにした。